### PR TITLE
Add description for IAM role, policy and permissions required for requester and accepter

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,162 @@ module "vpc_peering_cross_account" {
 
   requester_aws_assume_role_arn             = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
   requester_region                          = "us-west-2"
-  requester_vpc_id                          = "vpc-XXXXXXXX"
+  requester_vpc_id                          = "vpc-xxxxxxxx"
   requester_allow_remote_vpc_dns_resolution = "true"
 
   accepter_aws_assume_role_arn             = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
   accepter_region                          = "us-east-1"
-  accepter_vpc_id                          = "vpc-YYYYYYYY"
+  accepter_vpc_id                          = "vpc-yyyyyyyy"
   accepter_allow_remote_vpc_dns_resolution = "true"
 }
 ```
+
+The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::XXXXXXXX:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+```
+
+and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the requester AWS account):
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute"
+      ],
+      "Resource": "arn:aws:ec2:*:XXXXXXXX:route-table/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyVpcPeeringConnectionOptions",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeRouteTables"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AcceptVpcPeeringConnection",
+        "ec2:DeleteVpcPeeringConnection",
+        "ec2:CreateVpcPeeringConnection",
+        "ec2:RejectVpcPeeringConnection"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:XXXXXXXX:vpc-peering-connection/*",
+        "arn:aws:ec2:*:XXXXXXXX:vpc/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags",
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:XXXXXXXX:vpc-peering-connection/*"
+    }
+  ]
+}
+```
+
+where `XXXXXXXX` is the requester AWS account ID.
+
+The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+
+__NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
+In the requester case, the requester account ID is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::XXXXXXXX:root"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {}
+    }
+  ]
+}
+```
+
+and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the accepter AWS account):
+
+```js
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute"
+      ],
+      "Resource": "arn:aws:ec2:*:YYYYYYYY:route-table/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeVpcPeeringConnections",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyVpcPeeringConnectionOptions",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeRouteTables"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AcceptVpcPeeringConnection",
+        "ec2:DeleteVpcPeeringConnection",
+        "ec2:CreateVpcPeeringConnection",
+        "ec2:RejectVpcPeeringConnection"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:YYYYYYYY:vpc-peering-connection/*",
+        "arn:aws:ec2:*:YYYYYYYY:vpc/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags",
+        "ec2:CreateTags"
+      ],
+      "Resource": "arn:aws:ec2:*:YYYYYYYY:vpc-peering-connection/*"
+    }
+  ]
+}
+```
+
+where `YYYYYYYY` is the accepter AWS account ID.
+
+For more information on IAM policies and permissions for VPC peering, see [Creating and managing VPC peering connections](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_IAM.html#vpcpeeringiam).
 
 
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,10 @@ The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM ro
 }
 ```
 
-and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the requester AWS account):
+and the following IAM Policy attached to it:
+
+__NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account
+
 
 ```js
 {
@@ -149,10 +152,8 @@ and the following IAM Policy attached to it (NOTE: the policy specifies the perm
 
 where `XXXXXXXX` is the requester AWS account ID.
 
-The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
 
-__NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
-In the requester case, the requester account ID is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM role should have the following Trust Policy:
 
 ```js
 {
@@ -170,7 +171,13 @@ In the requester case, the requester account ID is the trusted entity. For the a
 }
 ```
 
-and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the accepter AWS account):
+__NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
+In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+
+and the following IAM Policy attached to it:
+
+__NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account
+
 
 ```js
 {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ module "vpc_peering_cross_account" {
 }
 ```
 
-The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM Role should have the following Trust Policy:
 
 ```js
 {
@@ -153,7 +153,7 @@ __NOTE:__ the policy specifies the permissions to create (with `terraform plan/a
 where `XXXXXXXX` is the requester AWS account ID.
 
 
-The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM role should have the following Trust Policy:
+The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM Role should have the following Trust Policy:
 
 ```js
 {
@@ -172,7 +172,8 @@ The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM rol
 ```
 
 __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
-In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+In the requester case, the requester account ID itself is the trusted entity.
+For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account `YYYYYYYY`.
 
 and the following IAM Policy attached to it:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ module "vpc_peering_cross_account" {
 
 The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM Role should have the following Trust Policy:
 
+<details><summary>Show Trust Policy</summary>
+
 ```js
 {
   "Version": "2012-10-17",
@@ -96,10 +98,14 @@ The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM Ro
 }
 ```
 
+</details>
+<br/>
+
 and the following IAM Policy attached to it:
 
 __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account
 
+<details><summary>Show IAM Policy</summary>
 
 ```js
 {
@@ -150,10 +156,15 @@ __NOTE:__ the policy specifies the permissions to create (with `terraform plan/a
 }
 ```
 
+</details>
+
 where `XXXXXXXX` is the requester AWS account ID.
 
+<br/>
 
 The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM Role should have the following Trust Policy:
+
+<details><summary>Show Trust Policy</summary>
 
 ```js
 {
@@ -171,6 +182,8 @@ The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM Rol
 }
 ```
 
+</details>
+
 __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
 In the requester case, the requester account ID itself is the trusted entity.
 For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account `YYYYYYYY`.
@@ -179,6 +192,7 @@ and the following IAM Policy attached to it:
 
 __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account
 
+<details><summary>Show IAM Policy</summary>
 
 ```js
 {
@@ -228,6 +242,8 @@ __NOTE:__ the policy specifies the permissions to create (with `terraform plan/a
   ]
 }
 ```
+
+</details>
 
 where `YYYYYYYY` is the accepter AWS account ID.
 

--- a/README.yaml
+++ b/README.yaml
@@ -162,10 +162,8 @@ usage: |-
 
   where `XXXXXXXX` is the requester AWS account ID.
 
-  The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
 
-  __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
-  In the requester case, the requester account ID is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+  The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
 
   ```js
   {
@@ -182,6 +180,9 @@ usage: |-
     ]
   }
   ```
+
+  __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
+  In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
 
   and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the accepter AWS account):
 

--- a/README.yaml
+++ b/README.yaml
@@ -91,7 +91,7 @@ usage: |-
   }
   ```
 
-  The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+  The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM Role should have the following Trust Policy:
 
   ```js
   {
@@ -166,7 +166,7 @@ usage: |-
   where `XXXXXXXX` is the requester AWS account ID.
 
 
-  The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM role should have the following Trust Policy:
+  The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM Role should have the following Trust Policy:
 
   ```js
   {

--- a/README.yaml
+++ b/README.yaml
@@ -93,6 +93,8 @@ usage: |-
 
   The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM Role should have the following Trust Policy:
 
+  <details><summary>Show Trust Policy</summary>
+
   ```js
   {
     "Version": "2012-10-17",
@@ -109,10 +111,14 @@ usage: |-
   }
   ```
 
+  </details>
+  <br/>
+
   and the following IAM Policy attached to it:
 
   __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account
 
+  <details><summary>Show IAM Policy</summary>
 
   ```js
   {
@@ -163,10 +169,15 @@ usage: |-
   }
   ```
 
+  </details>
+
   where `XXXXXXXX` is the requester AWS account ID.
 
+  <br/>
 
   The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM Role should have the following Trust Policy:
+
+  <details><summary>Show Trust Policy</summary>
 
   ```js
   {
@@ -184,6 +195,8 @@ usage: |-
   }
   ```
 
+  </details>
+
   __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
   In the requester case, the requester account ID itself is the trusted entity.
   For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account `YYYYYYYY`.
@@ -192,6 +205,7 @@ usage: |-
 
   __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account
 
+  <details><summary>Show IAM Policy</summary>
 
   ```js
   {
@@ -241,6 +255,8 @@ usage: |-
     ]
   }
   ```
+
+  </details>
 
   where `YYYYYYYY` is the accepter AWS account ID.
 

--- a/README.yaml
+++ b/README.yaml
@@ -109,7 +109,10 @@ usage: |-
   }
   ```
 
-  and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the requester AWS account):
+  and the following IAM Policy attached to it:
+
+  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account)
+
 
   ```js
   {
@@ -184,7 +187,10 @@ usage: |-
   __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
   In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
 
-  and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the accepter AWS account):
+  and the following IAM Policy attached to it:
+
+  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account)
+
 
   ```js
   {

--- a/README.yaml
+++ b/README.yaml
@@ -81,15 +81,162 @@ usage: |-
 
     requester_aws_assume_role_arn             = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
     requester_region                          = "us-west-2"
-    requester_vpc_id                          = "vpc-XXXXXXXX"
+    requester_vpc_id                          = "vpc-xxxxxxxx"
     requester_allow_remote_vpc_dns_resolution = "true"
 
     accepter_aws_assume_role_arn             = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
     accepter_region                          = "us-east-1"
-    accepter_vpc_id                          = "vpc-YYYYYYYY"
+    accepter_vpc_id                          = "vpc-yyyyyyyy"
     accepter_allow_remote_vpc_dns_resolution = "true"
   }
   ```
+
+  The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+
+  ```js
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::XXXXXXXX:root"
+        },
+        "Action": "sts:AssumeRole",
+        "Condition": {}
+      }
+    ]
+  }
+  ```
+
+  and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the requester AWS account):
+
+  ```js
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateRoute",
+          "ec2:DeleteRoute"
+        ],
+        "Resource": "arn:aws:ec2:*:XXXXXXXX:route-table/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeVpcs",
+          "ec2:ModifyVpcPeeringConnectionOptions",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcAttribute",
+          "ec2:DescribeRouteTables"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:AcceptVpcPeeringConnection",
+          "ec2:DeleteVpcPeeringConnection",
+          "ec2:CreateVpcPeeringConnection",
+          "ec2:RejectVpcPeeringConnection"
+        ],
+        "Resource": [
+          "arn:aws:ec2:*:XXXXXXXX:vpc-peering-connection/*",
+          "arn:aws:ec2:*:XXXXXXXX:vpc/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteTags",
+          "ec2:CreateTags"
+        ],
+        "Resource": "arn:aws:ec2:*:XXXXXXXX:vpc-peering-connection/*"
+      }
+    ]
+  }
+  ```
+
+  where `XXXXXXXX` is the requester AWS account ID.
+
+  The `arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+
+  __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
+  In the requester case, the requester account ID is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+
+  ```js
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "AWS": "arn:aws:iam::XXXXXXXX:root"
+        },
+        "Action": "sts:AssumeRole",
+        "Condition": {}
+      }
+    ]
+  }
+  ```
+
+  and the following IAM Policy attached to it (NOTE: the policy specifies the permissions to create the required resources in the accepter AWS account):
+
+  ```js
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:CreateRoute",
+          "ec2:DeleteRoute"
+        ],
+        "Resource": "arn:aws:ec2:*:YYYYYYYY:route-table/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DescribeVpcPeeringConnections",
+          "ec2:DescribeVpcs",
+          "ec2:ModifyVpcPeeringConnectionOptions",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeVpcAttribute",
+          "ec2:DescribeRouteTables"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:AcceptVpcPeeringConnection",
+          "ec2:DeleteVpcPeeringConnection",
+          "ec2:CreateVpcPeeringConnection",
+          "ec2:RejectVpcPeeringConnection"
+        ],
+        "Resource": [
+          "arn:aws:ec2:*:YYYYYYYY:vpc-peering-connection/*",
+          "arn:aws:ec2:*:YYYYYYYY:vpc/*"
+        ]
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:DeleteTags",
+          "ec2:CreateTags"
+        ],
+        "Resource": "arn:aws:ec2:*:YYYYYYYY:vpc-peering-connection/*"
+      }
+    ]
+  }
+  ```
+
+  where `YYYYYYYY` is the accepter AWS account ID.
+
+  For more information on IAM policies and permissions for VPC peering, see [Creating and managing VPC peering connections](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_IAM.html#vpcpeeringiam).
 
 references:
   - name: "What is VPC Peering?"

--- a/README.yaml
+++ b/README.yaml
@@ -111,7 +111,7 @@ usage: |-
 
   and the following IAM Policy attached to it:
 
-  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account)
+  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the requester AWS account
 
 
   ```js
@@ -166,7 +166,7 @@ usage: |-
   where `XXXXXXXX` is the requester AWS account ID.
 
 
-  The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` requester IAM role should have the following Trust Policy:
+  The `arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test` accepter IAM role should have the following Trust Policy:
 
   ```js
   {
@@ -184,12 +184,12 @@ usage: |-
   }
   ```
 
-  __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it specifies who can assume the IAM Role.
+  __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
   In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
 
   and the following IAM Policy attached to it:
 
-  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account)
+  __NOTE:__ the policy specifies the permissions to create (with `terraform plan/apply`) and delete (with `terraform destroy`) all the required resources in the accepter AWS account
 
 
   ```js

--- a/README.yaml
+++ b/README.yaml
@@ -185,7 +185,8 @@ usage: |-
   ```
 
   __NOTE__: The accepter Trust Policy is the same as the requester Trust Policy since it defines who can assume the IAM Role.
-  In the requester case, the requester account ID itself is the trusted entity. For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account.
+  In the requester case, the requester account ID itself is the trusted entity.
+  For the accepter, the Trust Policy specifies that the requester account ID `XXXXXXXX` can assume the role in the accepter AWS account `YYYYYYYY`.
 
   and the following IAM Policy attached to it:
 


### PR DESCRIPTION
## what
* Add description for IAM role, policy and permissions required for requester and accepter

## why
* Show complete and tested IAM Trust Policy and IAM Policy document with the minimum required permissions to create a VPC peering between the requester and accepter VPCs in different AWS accounts

