### PR TITLE
wait few seconds before attaching options to peering

### DIFF
--- a/accepter.tf
+++ b/accepter.tf
@@ -120,6 +120,7 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
 
 resource "aws_vpc_peering_connection_options" "accepter" {
   provider                  = "aws.accepter"
+  depends_on                = ["null_resource.await_active_peering"]
   vpc_peering_connection_id = "${join("", aws_vpc_peering_connection.requester.*.id)}"
 
   accepter {

--- a/variables.tf
+++ b/variables.tf
@@ -40,3 +40,8 @@ variable "auto_accept" {
   default     = "true"
   description = "Automatically accept the peering"
 }
+
+variable "await_peering" {
+  default     = 0
+  description = "Seconds to wait before attaching options to peering"
+}


### PR DESCRIPTION
Not sure if this is something you want to have in the master but it solves https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account/issues/8.

Outside of the module there is no way awaiting the peering connection to become active. 

- Optionally await peering connection with a fixed amount of seconds
- 30 seconds was in my case sufficient 
- Set to 0 (default) will not change anything

No BC

/cc @aknysh @jdn-za

We can also put more effort into and check the current peering status in a sleep loop