### PR TITLE
Make the "enabled" flag work for resource aws_vpc_peering_connection_options

### DIFF
--- a/accepter.tf
+++ b/accepter.tf
@@ -103,6 +103,7 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
+  count                     = local.count
   provider                  = aws.accepter
   vpc_peering_connection_id = local.active_vpc_peering_connection_id
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -73,7 +73,7 @@ data "aws_route_tables" "accepter" {
 }
 
 locals {
-  accepter_aws_route_table_ids           = distinct(sort(data.aws_route_tables.accepter[0].ids))
+  accepter_aws_route_table_ids           = try(distinct(sort(data.aws_route_tables.accepter[0].ids)), "")
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
   accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)

--- a/requester.tf
+++ b/requester.tf
@@ -118,6 +118,7 @@ locals {
 }
 
 resource "aws_vpc_peering_connection_options" "requester" {
+  count         = local.count
   provider = aws.requester
 
   # As options can't be set until the connection has been accepted

--- a/requester.tf
+++ b/requester.tf
@@ -118,7 +118,7 @@ locals {
 }
 
 resource "aws_vpc_peering_connection_options" "requester" {
-  count         = local.count
+  count    = local.count
   provider = aws.requester
 
   # As options can't be set until the connection has been accepted


### PR DESCRIPTION
## Make the enabled flag work

We are using this module in several environments, sometime enabled and sometimes not. It looks like enabled==false causes problems because an expression can not be evaluated when count==0. This PR puts a try around this expression and also fixes a follow-up problem where the default of the try causes an error (some resources have no count parameter)