### PR TITLE
Allow filtering subnets using tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -312,6 +313,7 @@ Available targets:
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
+| accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
 | accepter\_vpc\_tags | Accepter VPC Tags filter | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `a` or `b`) | `list(string)` | `[]` | no |
@@ -323,6 +325,7 @@ Available targets:
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
+| requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |
 | requester\_vpc\_tags | Requester VPC Tags filter | `map(string)` | `{}` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
@@ -337,6 +340,7 @@ Available targets:
 | requester\_accept\_status | Requester VPC peering connection request status |
 | requester\_connection\_id | Requester VPC peering connection ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -55,6 +55,7 @@ data "aws_subnet_ids" "accepter" {
   count    = local.count
   provider = aws.accepter
   vpc_id   = local.accepter_vpc_id
+  tags     = var.accepter_subnet_tags
 }
 
 locals {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -20,6 +21,7 @@
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
+| accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
 | accepter\_vpc\_tags | Accepter VPC Tags filter | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `a` or `b`) | `list(string)` | `[]` | no |
@@ -31,6 +33,7 @@
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
+| requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |
 | requester\_vpc\_tags | Requester VPC Tags filter | `map(string)` | `{}` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
@@ -45,3 +48,4 @@
 | requester\_accept\_status | Requester VPC peering connection request status |
 | requester\_connection\_id | Requester VPC peering connection ID |
 
+<!-- markdownlint-restore -->

--- a/requester.tf
+++ b/requester.tf
@@ -8,6 +8,12 @@ variable "requester_region" {
   description = "Requester AWS region"
 }
 
+variable "requester_subnet_tags" {
+  type        = map(string)
+  description = "Only add peer routes to requester VPC route tables of subnets matching these tags"
+  default     = {}
+}
+
 variable "requester_vpc_id" {
   type        = string
   description = "Requester VPC ID filter"
@@ -84,6 +90,7 @@ data "aws_subnet_ids" "requester" {
   count    = local.count
   provider = aws.requester
   vpc_id   = local.requester_vpc_id
+  tags     = var.requester_subnet_tags
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "accepter_vpc_tags" {
   default     = {}
 }
 
+variable "accepter_subnet_tags" {
+  type        = map(string)
+  description = "Only add peer routes to accepter VPC route tables of subnets matching these tags"
+  default     = {}
+}
+
 variable "accepter_allow_remote_vpc_dns_resolution" {
   type        = bool
   default     = true


### PR DESCRIPTION
## what
* Caller can supply tags for both the acceptor and requestor VPCs, and if present, peering routes will only be added to route tables of subnets matching those tags.
* Default behavior is unchanged.

## why
* Support environments with private subnets that shouldn't be allowed to communicate with peer VPCs.