### PR TITLE
Bump required versions of aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,15 +296,15 @@ Available targets:
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12 |
-| aws | ~> 2.0 |
+| aws | >= 2.0, < 4.0.0 |
 | null | ~> 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws.accepter | ~> 2.0 |
-| aws.requester | ~> 2.0 |
+| aws.accepter | >= 2.0, < 4.0.0 |
+| aws.requester | >= 2.0, < 4.0.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws  = "~> 2.0"
+    aws  = ">= 2.0, < 4.0.0"
     null = "~> 2.0"
   }
 }


### PR DESCRIPTION
## what
Bump version for aws provider.

## why
Currently pinned to v2.0 which is pretty old and conflicts with newer versions of other modules such as the aws vpc module.

## references
closes #24 