### PR TITLE
Add option to skip ec2 profile credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ Available targets:
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |
 | requester\_vpc\_tags | Requester VPC Tags filter | `map(string)` | `{}` | no |
+| skip\_metadata\_api\_check | Don't use the credentials of EC2 instance profile | `bool` | `false` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
 | tags | Additional tags (e.g. `{"BusinessUnit" = "XYZ"`) | `map(string)` | `{}` | no |
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -1,7 +1,8 @@
 # Accepter's credentials
 provider "aws" {
-  alias  = "accepter"
-  region = var.accepter_region
+  alias                   = "accepter"
+  region                  = var.accepter_region
+  skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {
     for_each = var.accepter_aws_assume_role_arn != "" ? ["true"] : []

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -36,6 +36,7 @@
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |
 | requester\_vpc\_tags | Requester VPC Tags filter | `map(string)` | `{}` | no |
+| skip\_metadata\_api\_check | Don't use the credentials of EC2 instance profile | `bool` | `false` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | n/a | yes |
 | tags | Additional tags (e.g. `{"BusinessUnit" = "XYZ"`) | `map(string)` | `{}` | no |
 

--- a/requester.tf
+++ b/requester.tf
@@ -34,8 +34,9 @@ variable "requester_allow_remote_vpc_dns_resolution" {
 
 # Requestors's credentials
 provider "aws" {
-  alias  = "requester"
-  region = var.requester_region
+  alias                   = "requester"
+  region                  = var.requester_region
+  skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {
     for_each = var.requester_aws_assume_role_arn != "" ? ["true"] : []

--- a/variables.tf
+++ b/variables.tf
@@ -76,3 +76,9 @@ variable "accepter_allow_remote_vpc_dns_resolution" {
   default     = true
   description = "Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC"
 }
+
+variable "skip_metadata_api_check" {
+  type        = bool
+  default     = false
+  description = "Don't use the credentials of EC2 instance profile"
+}


### PR DESCRIPTION
## what
Add optional input `skip_metadata_api_check` for the aws provider [doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#skip_metadata_api_check)


## why
When running the terraform in eks, we want terraform to use the iam role associated with the pod instead of the ec2 instance profile.

## references
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

