### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Are you using this project or any of our other projects? Consider [leaving a tes
 Check out these related projects.
 
 - [terraform-aws-vpc](https://github.com/cloudposse/terraform-aws-vpc) - Terraform Module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways
-- [terraform-aws-vpc-peering](https://github.com/cloudposse/terraform-aws-vpc) - Terraform module to create a peering connection between two VPCs in the same AWS account
+- [terraform-aws-vpc-peering](https://github.com/cloudposse/terraform-aws-vpc-peering) - Terraform module to create a peering connection between two VPCs in the same AWS account
 - [terraform-aws-kops-vpc-peering](https://github.com/cloudposse/terraform-aws-kops-vpc-peering) - Terraform module to create a peering connection between a backing services VPC and a VPC created by Kops
 
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Are you using this project or any of our other projects? Consider [leaving a tes
 Check out these related projects.
 
 - [terraform-aws-vpc](https://github.com/cloudposse/terraform-aws-vpc) - Terraform Module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways
-- [terraform-aws-vpc-peering](https://github.com/cloudposse/terraform-aws-vpc-peering) - Terraform module to create a peering connection between two VPCs in the same AWS account
+- [terraform-aws-vpc-peering](https://github.com/cloudposse/terraform-aws-vpc) - Terraform module to create a peering connection between two VPCs in the same AWS account
 - [terraform-aws-kops-vpc-peering](https://github.com/cloudposse/terraform-aws-kops-vpc-peering) - Terraform module to create a peering connection between a backing services VPC and a VPC created by Kops
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -41,7 +41,7 @@ related:
     url: "https://github.com/cloudposse/terraform-aws-vpc"
   - name: "terraform-aws-vpc-peering"
     description: "Terraform module to create a peering connection between two VPCs in the same AWS account"
-    url: "https://github.com/cloudposse/terraform-aws-vpc"
+    url: "https://github.com/cloudposse/terraform-aws-vpc-peering"
   - name: "terraform-aws-kops-vpc-peering"
     description: "Terraform module to create a peering connection between a backing services VPC and a VPC created by Kops"
     url: "https://github.com/cloudposse/terraform-aws-kops-vpc-peering"


### PR DESCRIPTION
fix link to `terraform-aws-vpc-peering` - it was pointing to `terraform-aws-vpc`
