### PR TITLE
Add optional profile for accepter and requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,8 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
-| accepter\_aws\_profile | Profile used to assume `accepter_aws_assume_role_arn` | `string` | `""` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
+| accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -362,8 +362,8 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
-| requester\_aws\_profile | Profile used to assume `requester_aws_assume_role_arn` | `string` | `""` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
+| requester\_aws\_profile | Profile used to assume `requester_aws_assume_role_arn` | `string` | `""` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
+| accepter\_aws\_profile | Profile used to assume `accepter_aws_assume_role_arn` | `string` | `""` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
@@ -361,6 +362,7 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
+| requester\_aws\_profile | Profile used to assume `requester_aws_assume_role_arn` | `string` | `""` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -336,6 +336,29 @@ Available targets:
 | aws.accepter | >= 2.0 |
 | aws.requester | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| accepter | cloudposse/label/null | 0.24.1 |
+| requester | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
+| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
+| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
+| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -363,7 +386,7 @@ Available targets:
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
-| requester\_aws\_profile | Profile used to assume `requester_aws_assume_role_arn` | `string` | `""` | no |
+| requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |
@@ -380,7 +403,6 @@ Available targets:
 | accepter\_connection\_id | Accepter VPC peering connection ID |
 | requester\_accept\_status | Requester VPC peering connection request status |
 | requester\_connection\_id | Requester VPC peering connection ID |
-
 <!-- markdownlint-restore -->
 
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -2,6 +2,7 @@
 provider "aws" {
   alias                   = "accepter"
   region                  = var.accepter_region
+  profile                 = var.accepter_aws_profile
   skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -20,6 +20,7 @@
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
+| accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -40,6 +41,7 @@
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
+| requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -14,6 +14,29 @@
 | aws.accepter | >= 2.0 |
 | aws.requester | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| accepter | cloudposse/label/null | 0.24.1 |
+| requester | cloudposse/label/null | 0.24.1 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
+| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
+| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
+| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -58,5 +81,4 @@
 | accepter\_connection\_id | Accepter VPC peering connection ID |
 | requester\_accept\_status | Requester VPC peering connection request status |
 | requester\_connection\_id | Requester VPC peering connection ID |
-
 <!-- markdownlint-restore -->

--- a/requester.tf
+++ b/requester.tf
@@ -1,3 +1,9 @@
+variable "requester_aws_profile" {
+  description = "Profile used to assume requester_aws_assume_role_arn"
+  type        = string
+  default     = ""
+}
+
 variable "requester_aws_assume_role_arn" {
   description = "Requester AWS Assume Role ARN"
   type        = string
@@ -36,6 +42,7 @@ variable "requester_allow_remote_vpc_dns_resolution" {
 provider "aws" {
   alias                   = "requester"
   region                  = var.requester_region
+  profile                 = var.requester_aws_profile
   skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "auto_accept" {
   description = "Automatically accept the peering"
 }
 
+variable "accepter_aws_profile" {
+  description = "Profile used to assume accepter_aws_assume_role_arn"
+  type        = string
+  default     = ""
+}
+
 variable "accepter_aws_assume_role_arn" {
   description = "Accepter AWS Assume Role ARN"
   type        = string


### PR DESCRIPTION
## what
- Allow user to pass in optional profile to be used when assuming the specified role.

## why

- As stated in the issue, if you normally configure `profile` in your aws provider block, plan will fail with the following message. This is because the default credentials don't have permission to assume the specified role.

```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


Error: error configuring Terraform AWS Provider: IAM Role (arn:aws:iam::XXXX:role/vpc-peering-role) cannot be assumed.

There are a number of possible causes of this - the most common are:
  * The credentials used in order to assume the role are invalid
  * The credentials do not have appropriate permission to assume the role
  * The role ARN is not valid

Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors

```

Also, there was a question of whether or not passing in an empty string would be okay for the AWS provider and it seems to work fine.

## references
closes https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account/issues/7