### PR TITLE
Add aws credentials into accepter and requester providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,11 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
+| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `""` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
+| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `""` | no |
+| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -385,8 +388,11 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
+| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `""` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
+| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `""` | no |
+| requester\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -350,14 +350,14 @@ Available targets:
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
-| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
 | [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
 | [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
 | [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
-| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
 | [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
 | [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
 
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -364,11 +364,11 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
-| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `""` | no |
+| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `null` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
-| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `""` | no |
-| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
+| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `null` | no |
+| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `null` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -388,11 +388,11 @@ Available targets:
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
-| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `""` | no |
+| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `null` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
-| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `""` | no |
-| requester\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
+| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `null` | no |
+| requester\_aws\_token | Session token for validating temporary credentials | `string` | `null` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -348,16 +348,16 @@ Available targets:
 
 | Name |
 |------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
-| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
-| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
-| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
-| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
-| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
-| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) |
+| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) |
+| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) |
+| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) |
 
 ## Inputs
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -11,6 +11,10 @@ provider "aws" {
       role_arn = var.accepter_aws_assume_role_arn
     }
   }
+
+  access_key = var.accepter_aws_access_key
+  secret_key = var.accepter_aws_secret_key
+  token      = var.accepter_aws_token
 }
 
 module "accepter" {

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -42,11 +42,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
-| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `""` | no |
+| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `null` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
-| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `""` | no |
-| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
+| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `null` | no |
+| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `null` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -66,11 +66,11 @@
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
-| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `""` | no |
+| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `null` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
-| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `""` | no |
-| requester\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
+| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `null` | no |
+| requester\_aws\_token | Session token for validating temporary credentials | `string` | `null` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,16 +26,16 @@
 
 | Name |
 |------|
-| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
-| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
-| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
-| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
-| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
-| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
-| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
-| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) |
+| [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) |
+| [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection) |
+| [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_accepter) |
+| [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_peering_connection_options) |
 
 ## Inputs
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -42,8 +42,11 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | accepter\_allow\_remote\_vpc\_dns\_resolution | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
+| accepter\_aws\_access\_key | Access key id to use in accepter account | `string` | `""` | no |
 | accepter\_aws\_assume\_role\_arn | Accepter AWS Assume Role ARN | `string` | n/a | yes |
 | accepter\_aws\_profile | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
+| accepter\_aws\_secret\_key | Secret access key to use in accepter account | `string` | `""` | no |
+| accepter\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
 | accepter\_region | Accepter AWS region | `string` | n/a | yes |
 | accepter\_subnet\_tags | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | accepter\_vpc\_id | Accepter VPC ID filter | `string` | `""` | no |
@@ -63,8 +66,11 @@
 | namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | requester\_allow\_remote\_vpc\_dns\_resolution | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
+| requester\_aws\_access\_key | Access key id to use in requester account | `string` | `""` | no |
 | requester\_aws\_assume\_role\_arn | Requester AWS Assume Role ARN | `string` | n/a | yes |
 | requester\_aws\_profile | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
+| requester\_aws\_secret\_key | Secret access key to use in requester account | `string` | `""` | no |
+| requester\_aws\_token | Session token for validating temporary credentials | `string` | `""` | no |
 | requester\_region | Requester AWS region | `string` | n/a | yes |
 | requester\_subnet\_tags | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | requester\_vpc\_id | Requester VPC ID filter | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -28,14 +28,14 @@
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/caller_identity) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/region) |
-| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
 | [aws_route_table](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_table) |
 | [aws_route_tables](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/route_tables) |
+| [aws_route](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/route) |
 | [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/subnet_ids) |
-| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
-| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
 | [aws_vpc_peering_connection_accepter](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_accepter) |
 | [aws_vpc_peering_connection_options](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection_options) |
+| [aws_vpc_peering_connection](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/vpc_peering_connection) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/data-sources/vpc) |
 
 ## Inputs
 

--- a/requester.tf
+++ b/requester.tf
@@ -4,9 +4,27 @@ variable "requester_aws_profile" {
   default     = ""
 }
 
+variable "requester_aws_access_key" {
+  description = "Access key id to use in requester account"
+  type        = string
+  default     = ""
+}
+
 variable "requester_aws_assume_role_arn" {
   description = "Requester AWS Assume Role ARN"
   type        = string
+}
+
+variable "requester_aws_secret_key" {
+  description = "Secret access key to use in requester account"
+  type        = string
+  default     = ""
+}
+
+variable "requester_aws_token" {
+  description = "Session token for validating temporary credentials"
+  type        = string
+  default     = ""
 }
 
 variable "requester_region" {
@@ -51,6 +69,10 @@ provider "aws" {
       role_arn = var.requester_aws_assume_role_arn
     }
   }
+
+  access_key = var.requester_aws_access_key
+  secret_key = var.requester_aws_secret_key
+  token      = var.requester_aws_token
 
 }
 

--- a/requester.tf
+++ b/requester.tf
@@ -7,7 +7,7 @@ variable "requester_aws_profile" {
 variable "requester_aws_access_key" {
   description = "Access key id to use in requester account"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "requester_aws_assume_role_arn" {
@@ -18,13 +18,13 @@ variable "requester_aws_assume_role_arn" {
 variable "requester_aws_secret_key" {
   description = "Secret access key to use in requester account"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "requester_aws_token" {
   description = "Session token for validating temporary credentials"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "requester_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "auto_accept" {
   description = "Automatically accept the peering"
 }
 
+variable "accepter_aws_access_key" {
+  description = "Access key id to use in accepter account"
+  type        = string
+  default     = ""
+}
+
 variable "accepter_aws_profile" {
   description = "Profile used to assume accepter_aws_assume_role_arn"
   type        = string
@@ -13,6 +19,18 @@ variable "accepter_aws_profile" {
 variable "accepter_aws_assume_role_arn" {
   description = "Accepter AWS Assume Role ARN"
   type        = string
+}
+
+variable "accepter_aws_secret_key" {
+  description = "Secret access key to use in accepter account"
+  type        = string
+  default     = ""
+}
+
+variable "accepter_aws_token" {
+  description = "Session token for validating temporary credentials"
+  type        = string
+  default     = ""
 }
 
 variable "accepter_region" {

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ variable "auto_accept" {
 variable "accepter_aws_access_key" {
   description = "Access key id to use in accepter account"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "accepter_aws_profile" {
@@ -24,13 +24,13 @@ variable "accepter_aws_assume_role_arn" {
 variable "accepter_aws_secret_key" {
   description = "Secret access key to use in accepter account"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "accepter_aws_token" {
   description = "Session token for validating temporary credentials"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "accepter_region" {


### PR DESCRIPTION
## what
* Adds AWS credentials variables into providers ( access key id, secret access key, session token)

## why
* I have a use case of using Hashicorp Vault to fetch AWS credentials, i need a way to pass these fetched credentials into the module.