### PR TITLE
Add `accepter_enabled` variable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,8 @@
 
 # Cloud Posse must review any changes to standard context definition,
 # but some changes can be rubber-stamped.
-**/*.tf       @cloudposse/engineering @cloudposse/approvers
-README.yaml   @cloudposse/engineering @cloudposse/approvers
+**/*.tf       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+README.yaml   @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 README.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 docs/*.md     @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
 

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -46,7 +46,7 @@ template: |
 
 replacers:
 # Remove irrelevant information from Renovate bot
-- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+- search: '/(?<=---\s+)+^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
   replace: ''
 # Remove Renovate bot banner image
 - search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,7 +3,9 @@ name: auto-release
 on:
   push:
     branches:
+      - main
       - master
+      - production
 
 jobs:
   publish:
@@ -14,7 +16,7 @@ jobs:
         id: get-merged-pull-request
         with:
           github_token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5
         if: "!contains(steps.get-merged-pull-request.outputs.labels, 'no-release')"
         with:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,5 +1,7 @@
 name: Validate Codeowners
 on:
+  workflow_dispatch:
+
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -371,10 +371,11 @@ Available targets:
 |------|-------------|------|---------|:--------:|
 | <a name="input_accepter_allow_remote_vpc_dns_resolution"></a> [accepter\_allow\_remote\_vpc\_dns\_resolution](#input\_accepter\_allow\_remote\_vpc\_dns\_resolution) | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
 | <a name="input_accepter_aws_access_key"></a> [accepter\_aws\_access\_key](#input\_accepter\_aws\_access\_key) | Access key id to use in accepter account | `string` | `null` | no |
-| <a name="input_accepter_aws_assume_role_arn"></a> [accepter\_aws\_assume\_role\_arn](#input\_accepter\_aws\_assume\_role\_arn) | Accepter AWS Assume Role ARN | `string` | n/a | yes |
+| <a name="input_accepter_aws_assume_role_arn"></a> [accepter\_aws\_assume\_role\_arn](#input\_accepter\_aws\_assume\_role\_arn) | Accepter AWS Assume Role ARN | `string` | `null` | no |
 | <a name="input_accepter_aws_profile"></a> [accepter\_aws\_profile](#input\_accepter\_aws\_profile) | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
 | <a name="input_accepter_aws_secret_key"></a> [accepter\_aws\_secret\_key](#input\_accepter\_aws\_secret\_key) | Secret access key to use in accepter account | `string` | `null` | no |
 | <a name="input_accepter_aws_token"></a> [accepter\_aws\_token](#input\_accepter\_aws\_token) | Session token for validating temporary credentials | `string` | `null` | no |
+| <a name="input_accepter_enabled"></a> [accepter\_enabled](#input\_accepter\_enabled) | Flag to enable/disable the accepter side of the peering connection | `bool` | `true` | no |
 | <a name="input_accepter_region"></a> [accepter\_region](#input\_accepter\_region) | Accepter AWS region | `string` | n/a | yes |
 | <a name="input_accepter_subnet_tags"></a> [accepter\_subnet\_tags](#input\_accepter\_subnet\_tags) | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | <a name="input_accepter_vpc_id"></a> [accepter\_vpc\_id](#input\_accepter\_vpc\_id) | Accepter VPC ID filter | `string` | `""` | no |
@@ -427,6 +428,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -434,8 +436,6 @@ Check out these related projects.
 - [terraform-aws-vpc](https://github.com/cloudposse/terraform-aws-vpc) - Terraform Module that defines a VPC with public/private subnets across multiple AZs with Internet Gateways
 - [terraform-aws-vpc-peering](https://github.com/cloudposse/terraform-aws-vpc-peering) - Terraform module to create a peering connection between two VPCs in the same AWS account
 - [terraform-aws-kops-vpc-peering](https://github.com/cloudposse/terraform-aws-kops-vpc-peering) - Terraform module to create a peering connection between a backing services VPC and a VPC created by Kops
-
-
 
 
 ## References

--- a/accepter.tf
+++ b/accepter.tf
@@ -18,27 +18,30 @@ provider "aws" {
 }
 
 module "accepter" {
-  source     = "cloudposse/label/null"
-  version    = "0.24.1"
+  source  = "cloudposse/label/null"
+  version = "0.24.1"
+
+  enabled = local.accepter_enabled
+
   attributes = var.add_attribute_tag ? ["accepter"] : []
-  tags       = var.add_attribute_tag ? { "Side" = "accepter" } : {}
+  tags       = var.add_attribute_tag ? { Side = "accepter" } : {}
 
   context = module.this.context
 }
 
 data "aws_caller_identity" "accepter" {
-  count    = local.count
+  count    = local.accepter_count
   provider = aws.accepter
 }
 
 data "aws_region" "accepter" {
-  count    = local.count
+  count    = local.accepter_count
   provider = aws.accepter
 }
 
 # Lookup accepter's VPC so that we can reference the CIDR
 data "aws_vpc" "accepter" {
-  count    = local.count
+  count    = local.accepter_count
   provider = aws.accepter
   id       = var.accepter_vpc_id
   tags     = var.accepter_vpc_tags
@@ -46,7 +49,7 @@ data "aws_vpc" "accepter" {
 
 # Lookup accepter subnets
 data "aws_subnet_ids" "accepter" {
-  count    = local.count
+  count    = local.accepter_count
   provider = aws.accepter
   vpc_id   = local.accepter_vpc_id
   tags     = var.accepter_subnet_tags
@@ -62,7 +65,7 @@ locals {
 
 # Lookup accepter route tables
 data "aws_route_table" "accepter" {
-  count     = module.this.enabled ? local.accepter_subnet_ids_count : 0
+  count     = local.accepter_enabled ? local.accepter_subnet_ids_count : 0
   provider  = aws.accepter
   subnet_id = element(local.accepter_subnet_ids, count.index)
 }
@@ -70,13 +73,13 @@ data "aws_route_table" "accepter" {
 locals {
   accepter_aws_route_table_ids           = try(distinct(sort(data.aws_route_table.accepter.*.route_table_id)), [])
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
+  accepter_cidr_block_associations       = try(flatten(data.aws_vpc.accepter.*.cidr_block_associations), [])
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 
 # Create routes from accepter to requester
 resource "aws_route" "accepter" {
-  count                     = module.this.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
+  count                     = local.accepter_enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
   provider                  = aws.accepter
   route_table_id            = local.accepter_aws_route_table_ids[floor(count.index / local.requester_cidr_block_associations_count)]
   destination_cidr_block    = local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
@@ -84,13 +87,13 @@ resource "aws_route" "accepter" {
   depends_on = [
     data.aws_route_table.accepter,
     aws_vpc_peering_connection_accepter.accepter,
-    aws_vpc_peering_connection.requester,
+    aws_vpc_peering_connection.requester
   ]
 }
 
 # Accepter's side of the connection.
 resource "aws_vpc_peering_connection_accepter" "accepter" {
-  count                     = local.count
+  count                     = local.accepter_count
   provider                  = aws.accepter
   vpc_peering_connection_id = join("", aws_vpc_peering_connection.requester.*.id)
   auto_accept               = var.auto_accept
@@ -98,7 +101,7 @@ resource "aws_vpc_peering_connection_accepter" "accepter" {
 }
 
 resource "aws_vpc_peering_connection_options" "accepter" {
-  count                     = local.count
+  count                     = local.accepter_count
   provider                  = aws.accepter
   vpc_peering_connection_id = local.active_vpc_peering_connection_id
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,10 +49,11 @@
 |------|-------------|------|---------|:--------:|
 | <a name="input_accepter_allow_remote_vpc_dns_resolution"></a> [accepter\_allow\_remote\_vpc\_dns\_resolution](#input\_accepter\_allow\_remote\_vpc\_dns\_resolution) | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
 | <a name="input_accepter_aws_access_key"></a> [accepter\_aws\_access\_key](#input\_accepter\_aws\_access\_key) | Access key id to use in accepter account | `string` | `null` | no |
-| <a name="input_accepter_aws_assume_role_arn"></a> [accepter\_aws\_assume\_role\_arn](#input\_accepter\_aws\_assume\_role\_arn) | Accepter AWS Assume Role ARN | `string` | n/a | yes |
+| <a name="input_accepter_aws_assume_role_arn"></a> [accepter\_aws\_assume\_role\_arn](#input\_accepter\_aws\_assume\_role\_arn) | Accepter AWS Assume Role ARN | `string` | `null` | no |
 | <a name="input_accepter_aws_profile"></a> [accepter\_aws\_profile](#input\_accepter\_aws\_profile) | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
 | <a name="input_accepter_aws_secret_key"></a> [accepter\_aws\_secret\_key](#input\_accepter\_aws\_secret\_key) | Secret access key to use in accepter account | `string` | `null` | no |
 | <a name="input_accepter_aws_token"></a> [accepter\_aws\_token](#input\_accepter\_aws\_token) | Session token for validating temporary credentials | `string` | `null` | no |
+| <a name="input_accepter_enabled"></a> [accepter\_enabled](#input\_accepter\_enabled) | Flag to enable/disable the accepter side of the peering connection | `bool` | `true` | no |
 | <a name="input_accepter_region"></a> [accepter\_region](#input\_accepter\_region) | Accepter AWS region | `string` | n/a | yes |
 | <a name="input_accepter_subnet_tags"></a> [accepter\_subnet\_tags](#input\_accepter\_subnet\_tags) | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | <a name="input_accepter_vpc_id"></a> [accepter\_vpc\_id](#input\_accepter\_vpc\_id) | Accepter VPC ID filter | `string` | `""` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -10,6 +10,7 @@ module "vpc_peering_cross_account" {
   requester_vpc_id                          = var.requester_vpc_id
   requester_allow_remote_vpc_dns_resolution = var.requester_allow_remote_vpc_dns_resolution
 
+  accepter_enabled                         = var.accepter_enabled
   accepter_aws_assume_role_arn             = var.accepter_aws_assume_role_arn
   accepter_region                          = var.accepter_region
   accepter_vpc_id                          = var.accepter_vpc_id

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -26,9 +26,16 @@ variable "requester_allow_remote_vpc_dns_resolution" {
   default     = true
 }
 
+variable "accepter_enabled" {
+  description = "Flag to enable/disable the accepter side of the peering connection"
+  type        = bool
+  default     = true
+}
+
 variable "accepter_aws_assume_role_arn" {
   type        = string
   description = "Accepter AWS Assume Role ARN"
+  default     = null
 }
 
 variable "accepter_region" {

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,7 @@
 locals {
-  count = module.this.enabled ? 1 : 0
-}
+  enabled = module.this.enabled
+  count   = local.enabled ? 1 : 0
 
+  accepter_enabled = local.enabled && var.accepter_enabled
+  accepter_count   = local.enabled && var.accepter_enabled ? 1 : 0
+}

--- a/requester.tf
+++ b/requester.tf
@@ -80,7 +80,7 @@ module "requester" {
   source     = "cloudposse/label/null"
   version    = "0.24.1"
   attributes = var.add_attribute_tag ? ["requester"] : []
-  tags       = var.add_attribute_tag ? { "Side" = "requester" } : {}
+  tags       = var.add_attribute_tag ? { Side = "requester" } : {}
 
   context = module.this.context
 }
@@ -119,7 +119,7 @@ locals {
 
 # Lookup requester route tables
 data "aws_route_table" "requester" {
-  count     = module.this.enabled ? local.requester_subnet_ids_count : 0
+  count     = local.enabled ? local.requester_subnet_ids_count : 0
   provider  = aws.requester
   subnet_id = element(local.requester_subnet_ids, count.index)
 }
@@ -139,11 +139,12 @@ resource "aws_vpc_peering_connection" "requester" {
 # Options can't be set until the connection has been accepted and is active,
 # so create an explicit dependency on the accepter when setting options.
 locals {
-  active_vpc_peering_connection_id = join("", aws_vpc_peering_connection_accepter.accepter.*.id)
+  active_vpc_peering_connection_id = local.accepter_enabled ? join("", aws_vpc_peering_connection_accepter.accepter.*.id) : null
 }
 
 resource "aws_vpc_peering_connection_options" "requester" {
-  count    = local.count
+  # Only provision the options if the accepter side of the peering connection is enabled
+  count    = local.accepter_count
   provider = aws.requester
 
   # As options can't be set until the connection has been accepted
@@ -164,7 +165,7 @@ locals {
 
 # Create routes from requester to accepter
 resource "aws_route" "requester" {
-  count                     = module.this.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
+  count                     = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
   provider                  = aws.requester
   route_table_id            = local.requester_aws_route_table_ids[floor(count.index / local.accepter_cidr_block_associations_count)]
   destination_cidr_block    = local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"]
@@ -172,7 +173,7 @@ resource "aws_route" "requester" {
   depends_on = [
     data.aws_route_table.requester,
     aws_vpc_peering_connection.requester,
-    aws_vpc_peering_connection_accepter.accepter,
+    aws_vpc_peering_connection_accepter.accepter
   ]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,12 @@ variable "auto_accept" {
   description = "Automatically accept the peering"
 }
 
+variable "accepter_enabled" {
+  description = "Flag to enable/disable the accepter side of the peering connection"
+  type        = bool
+  default     = true
+}
+
 variable "accepter_aws_access_key" {
   description = "Access key id to use in accepter account"
   type        = string
@@ -19,6 +25,7 @@ variable "accepter_aws_profile" {
 variable "accepter_aws_assume_role_arn" {
   description = "Accepter AWS Assume Role ARN"
   type        = string
+  default     = null
 }
 
 variable "accepter_aws_secret_key" {


### PR DESCRIPTION
## what
* Add `accepter_enabled` variable

## why
* Allow provisioning only the requester side of the peering connection
* Useful in cases where the accepter side of the connection is managed manually

