### PR TITLE
Remove unused provider and bump dynamic-subnets version

### DIFF
--- a/examples/vpc-only/main.tf
+++ b/examples/vpc-only/main.tf
@@ -12,7 +12,7 @@ module "requester_vpc" {
 
 module "requester_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.38.0"
+  version              = "0.39.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.requester_vpc.vpc_id
   igw_id               = module.requester_vpc.igw_id
@@ -33,7 +33,7 @@ module "accepter_vpc" {
 
 module "accepter_subnets" {
   source               = "cloudposse/dynamic-subnets/aws"
-  version              = "0.38.0"
+  version              = "0.39.0"
   availability_zones   = var.availability_zones
   vpc_id               = module.accepter_vpc.vpc_id
   igw_id               = module.accepter_vpc.igw_id

--- a/examples/vpc-only/versions.tf
+++ b/examples/vpc-only/versions.tf
@@ -6,17 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
   }
 }


### PR DESCRIPTION
## what
* Remove unused providers
* Bump dynamic-subnets module to 0.39.0

## why
* Requiring the deprecated `template` provider makes the module unusable from an ARM based machine.



