### PR TITLE
Replace deprecated data source 'aws_subnet_ids'

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,8 +360,8 @@ Available targets:
 | [aws_route_table.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 | [aws_route_tables.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
 | [aws_route_tables.default_rts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
-| [aws_subnet_ids.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnets.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [aws_vpc.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -38,8 +38,8 @@
 | [aws_route_table.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_table) | data source |
 | [aws_route_tables.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
 | [aws_route_tables.default_rts](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route_tables) | data source |
-| [aws_subnet_ids.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) | data source |
 | [aws_subnets.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
+| [aws_subnets.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.accepter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 | [aws_vpc.requester](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/requester.tf
+++ b/requester.tf
@@ -104,15 +104,18 @@ data "aws_vpc" "requester" {
 }
 
 # Lookup requester subnets
-data "aws_subnet_ids" "requester" {
+data "aws_subnets" "requester" {
   count    = local.count
   provider = aws.requester
-  vpc_id   = local.requester_vpc_id
-  tags     = var.requester_subnet_tags
+  filter {
+    name   = "vpc-id"
+    values = [local.requester_vpc_id]
+  }
+  tags = var.requester_subnet_tags
 }
 
 locals {
-  requester_subnet_ids       = try(distinct(sort(flatten(data.aws_subnet_ids.requester.*.ids))), [])
+  requester_subnet_ids       = try(distinct(sort(flatten(data.aws_subnets.requester.*.ids))), [])
   requester_subnet_ids_count = length(local.requester_subnet_ids)
   requester_vpc_id           = join("", data.aws_vpc.requester.*.id)
 }


### PR DESCRIPTION
## what
*  Data source `aws_subnet_ids` was replaced with `aws_subnet` for requester. This was already implemented for accepter.

## why
* `aws_subnet_ids` has been deprecated and will be removed.

## references
* https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids

