### PR TITLE
Use cloudposse/template for arm support

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-vpc-peering-multi-account&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-vpc-peering-multi-account&utm_content=website
@@ -622,3 +622,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account
   [share_email]: mailto:?subject=terraform-aws-vpc-peering-multi-account&body=https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-vpc-peering-multi-account?pixel&cs=github&cm=readme&an=terraform-aws-vpc-peering-multi-account
+<!-- markdownlint-restore -->

--- a/examples/vpc-only/versions.tf
+++ b/examples/vpc-only/versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     template = {
       source  = "cloudposse/template"
-      version = ">= 2.0"
+      version = ">= 2.2"
     }
   }
 }

--- a/examples/vpc-only/versions.tf
+++ b/examples/vpc-only/versions.tf
@@ -15,7 +15,7 @@ terraform {
       version = ">= 1.3"
     }
     template = {
-      source  = "hashicorp/template"
+      source  = "cloudposse/template"
       version = ">= 2.0"
     }
   }


### PR DESCRIPTION
## what
* Use cloudposse/template for arm support

## why
* The new cloudposse/template provider has a darwin arm binary for M1 laptops

## references
* https://github.com/cloudposse/terraform-provider-template
* https://registry.terraform.io/providers/cloudposse/template/latest

