### PR TITLE
IPv6 communication over VPC peering

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-vpc-peering-multi-account&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-vpc-peering-multi-account&utm_content=website
@@ -622,3 +622,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account
   [share_email]: mailto:?subject=terraform-aws-vpc-peering-multi-account&body=https://github.com/cloudposse/terraform-aws-vpc-peering-multi-account
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-vpc-peering-multi-account?pixel&cs=github&cm=readme&an=terraform-aws-vpc-peering-multi-account
+<!-- markdownlint-restore -->

--- a/accepter.tf
+++ b/accepter.tf
@@ -92,7 +92,7 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
+  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations, data.aws_vpc.accepter.*.ipv6_cidr_block ? [] : [])
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -92,7 +92,8 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations, data.aws_vpc.accepter.*.ipv6_cidr_block ? [] : [])
+  accepter_ipv6_cidr_block_associations  = flatten(data.aws_vpc.accepter.*.ipv6_cidr_block ? [] : [])
+  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -92,7 +92,7 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_ipv6_cidr_block_associations  = flatten(data.aws_vpc.accepter.*.ipv6_cidr_block ? [] : [])
+  accepter_ipv6_cidr_blocks              = flatten(length(data.aws_vpc.accepter.*.ipv6_cidr_block) > 0 ? [data.aws_vpc.accepter.*.ipv6_cidr_block] : [])
   accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }

--- a/accepter.tf
+++ b/accepter.tf
@@ -99,7 +99,7 @@ locals {
   ] : [])
   accepter_cidr_block_associations = flatten([
     data.aws_vpc.accepter.*.cidr_block_associations,
-    accepter_ipv6_cidr_blocks
+    local.accepter_ipv6_cidr_blocks
   ])
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }

--- a/accepter.tf
+++ b/accepter.tf
@@ -109,8 +109,8 @@ resource "aws_route" "accepter" {
   count                       = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
   provider                    = aws.accepter
   route_table_id              = local.accepter_aws_route_table_ids[floor(count.index / local.requester_cidr_block_associations_count)]
-  destination_cidr_block      = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? "" : local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
-  destination_ipv6_cidr_block = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"] : ""
+  destination_cidr_block      = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? null : local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
+  destination_ipv6_cidr_block = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"] : null
   vpc_peering_connection_id   = join("", aws_vpc_peering_connection.requester.*.id)
   depends_on = [
     data.aws_route_tables.accepter,

--- a/accepter.tf
+++ b/accepter.tf
@@ -109,8 +109,8 @@ resource "aws_route" "accepter" {
   count                       = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
   provider                    = aws.accepter
   route_table_id              = local.accepter_aws_route_table_ids[floor(count.index / local.requester_cidr_block_associations_count)]
-  destination_cidr_block      = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? null : local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
-  destination_ipv6_cidr_block = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"] : null
+  destination_cidr_block      = length(split(":", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) > 1 ? null : local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
+  destination_ipv6_cidr_block = length(split(":", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) > 1 ? local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"] : null
   vpc_peering_connection_id   = join("", aws_vpc_peering_connection.requester.*.id)
   depends_on = [
     data.aws_route_tables.accepter,

--- a/accepter.tf
+++ b/accepter.tf
@@ -88,16 +88,16 @@ data "aws_route_tables" "default_rts" {
 }
 
 locals {
-  accepter_aws_default_rt_id             = join("", flatten(data.aws_route_tables.default_rts.*.ids))
-  accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
-  accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
-  accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_ipv6_cidr_blocks              = flatten(length(data.aws_vpc.accepter.*.ipv6_cidr_block) > 0 ? [
-    for vpc_temp in data.aws_vpc.accepter: {
+  accepter_aws_default_rt_id         = join("", flatten(data.aws_route_tables.default_rts.*.ids))
+  accepter_aws_rt_map                = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
+  accepter_aws_route_table_ids       = distinct(sort(values(local.accepter_aws_rt_map)))
+  accepter_aws_route_table_ids_count = length(local.accepter_aws_route_table_ids)
+  accepter_ipv6_cidr_blocks = flatten(length(data.aws_vpc.accepter.*.ipv6_cidr_block) > 0 ? [
+    for vpc_temp in data.aws_vpc.accepter : {
       cidr_block = vpc_temp.ipv6_cidr_block
     }
   ] : [])
-  accepter_cidr_block_associations       = flatten([
+  accepter_cidr_block_associations = flatten([
     data.aws_vpc.accepter.*.cidr_block_associations,
     accepter_ipv6_cidr_blocks
   ])

--- a/accepter.tf
+++ b/accepter.tf
@@ -92,8 +92,15 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_ipv6_cidr_blocks              = flatten(length(data.aws_vpc.accepter.*.ipv6_cidr_block) > 0 ? [data.aws_vpc.accepter.*.ipv6_cidr_block] : [])
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
+  accepter_ipv6_cidr_blocks              = flatten(length(data.aws_vpc.accepter.*.ipv6_cidr_block) > 0 ? [
+    for vpc_temp in data.aws_vpc.accepter: {
+      cidr_block = vpc_temp.ipv6_cidr_block
+    }
+  ] : [])
+  accepter_cidr_block_associations       = flatten([
+    data.aws_vpc.accepter.*.cidr_block_associations,
+    accepter_ipv6_cidr_blocks
+  ])
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 

--- a/accepter.tf
+++ b/accepter.tf
@@ -106,11 +106,12 @@ locals {
 
 # Create routes from accepter to requester
 resource "aws_route" "accepter" {
-  count                     = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
-  provider                  = aws.accepter
-  route_table_id            = local.accepter_aws_route_table_ids[floor(count.index / local.requester_cidr_block_associations_count)]
-  destination_cidr_block    = local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
-  vpc_peering_connection_id = join("", aws_vpc_peering_connection.requester.*.id)
+  count                       = local.enabled ? local.accepter_aws_route_table_ids_count * local.requester_cidr_block_associations_count : 0
+  provider                    = aws.accepter
+  route_table_id              = local.accepter_aws_route_table_ids[floor(count.index / local.requester_cidr_block_associations_count)]
+  destination_cidr_block      = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? "" : local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"]
+  destination_ipv6_cidr_block = can(regex("::", local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"])) ? local.requester_cidr_block_associations[count.index % local.requester_cidr_block_associations_count]["cidr_block"] : ""
+  vpc_peering_connection_id   = join("", aws_vpc_peering_connection.requester.*.id)
   depends_on = [
     data.aws_route_tables.accepter,
     aws_vpc_peering_connection_accepter.accepter,

--- a/requester.tf
+++ b/requester.tf
@@ -160,8 +160,8 @@ resource "aws_vpc_peering_connection_options" "requester" {
 }
 
 locals {
-  requester_aws_route_table_ids           = try(distinct(sort(data.aws_route_table.requester.*.route_table_id)), [])
-  requester_aws_route_table_ids_count     = length(local.requester_aws_route_table_ids)
+  requester_aws_route_table_ids       = try(distinct(sort(data.aws_route_table.requester.*.route_table_id)), [])
+  requester_aws_route_table_ids_count = length(local.requester_aws_route_table_ids)
   requester_ipv6_cidr_blocks = flatten(length(data.aws_vpc.requester.*.ipv6_cidr_block) > 0 ? [
     for vpc_temp in data.aws_vpc.requester : {
       cidr_block = vpc_temp.ipv6_cidr_block

--- a/requester.tf
+++ b/requester.tf
@@ -179,8 +179,8 @@ resource "aws_route" "requester" {
   count                       = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
   provider                    = aws.requester
   route_table_id              = local.requester_aws_route_table_ids[floor(count.index / local.accepter_cidr_block_associations_count)]
-  destination_cidr_block      = can(regex("::", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) ? null : local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"]
-  destination_ipv6_cidr_block = can(regex("::", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) ? local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"] : null
+  destination_cidr_block      = length(split(":", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) > 1 ? null : local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"]
+  destination_ipv6_cidr_block = length(split(":", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) > 1 ? local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"] : null
   vpc_peering_connection_id   = join("", aws_vpc_peering_connection.requester.*.id)
   depends_on = [
     data.aws_route_table.requester,

--- a/requester.tf
+++ b/requester.tf
@@ -168,11 +168,12 @@ locals {
 
 # Create routes from requester to accepter
 resource "aws_route" "requester" {
-  count                     = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
-  provider                  = aws.requester
-  route_table_id            = local.requester_aws_route_table_ids[floor(count.index / local.accepter_cidr_block_associations_count)]
-  destination_cidr_block    = local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"]
-  vpc_peering_connection_id = join("", aws_vpc_peering_connection.requester.*.id)
+  count                       = local.enabled ? local.requester_aws_route_table_ids_count * local.accepter_cidr_block_associations_count : 0
+  provider                    = aws.requester
+  route_table_id              = local.requester_aws_route_table_ids[floor(count.index / local.accepter_cidr_block_associations_count)]
+  destination_cidr_block      = can(regex("::", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) ? null : local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"]
+  destination_ipv6_cidr_block = can(regex("::", local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"])) ? local.accepter_cidr_block_associations[count.index % local.accepter_cidr_block_associations_count]["cidr_block"] : null
+  vpc_peering_connection_id   = join("", aws_vpc_peering_connection.requester.*.id)
   depends_on = [
     data.aws_route_table.requester,
     aws_vpc_peering_connection.requester,

--- a/requester.tf
+++ b/requester.tf
@@ -162,7 +162,15 @@ resource "aws_vpc_peering_connection_options" "requester" {
 locals {
   requester_aws_route_table_ids           = try(distinct(sort(data.aws_route_table.requester.*.route_table_id)), [])
   requester_aws_route_table_ids_count     = length(local.requester_aws_route_table_ids)
-  requester_cidr_block_associations       = flatten(data.aws_vpc.requester.*.cidr_block_associations)
+  requester_ipv6_cidr_blocks = flatten(length(data.aws_vpc.requester.*.ipv6_cidr_block) > 0 ? [
+    for vpc_temp in data.aws_vpc.requester : {
+      cidr_block = vpc_temp.ipv6_cidr_block
+    }
+  ] : [])
+  requester_cidr_block_associations = flatten([
+    data.aws_vpc.requester.*.cidr_block_associations,
+    local.requester_ipv6_cidr_blocks
+  ])
   requester_cidr_block_associations_count = length(local.requester_cidr_block_associations)
 }
 


### PR DESCRIPTION
## what
* Allow IPv6 communication b/w VPCs over VPC peering

## why
* Application hosted in VPC-1 wants to access resources hosted in private subnet of VPC-2 over IPv6.

