### PR TITLE
fix: add only associated cidrs

### DIFF
--- a/accepter.tf
+++ b/accepter.tf
@@ -92,7 +92,7 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
+  accepter_cidr_block_associations       = [for cidr in flatten(data.aws_vpc.accepter.*.cidr_block_associations) : cidr if cidr.state == "associated"]
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 

--- a/requester.tf
+++ b/requester.tf
@@ -162,7 +162,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 locals {
   requester_aws_route_table_ids           = try(distinct(sort(data.aws_route_table.requester.*.route_table_id)), [])
   requester_aws_route_table_ids_count     = length(local.requester_aws_route_table_ids)
-  requester_cidr_block_associations       = flatten(data.aws_vpc.requester.*.cidr_block_associations)
+  requester_cidr_block_associations       = [for cidr in flatten(data.aws_vpc.requester.*.cidr_block_associations) : cidr if cidr.state == "associated"]
   requester_cidr_block_associations_count = length(local.requester_cidr_block_associations)
 }
 


### PR DESCRIPTION
## what
* filter associated vpc cidrs by state
* add only cidrs with state "associated"
* drop cidrs with state "disassociated"

## why
* the data source "aws_vpc" return all cidrs, no matter if the state is "associated" or "disassociated"
* prevent duplicate cidrs, if the same cidr is present with the state "associated" and "disassociated"


