### PR TITLE
Ability to exclude cidr associations from routes that are created

### DIFF
--- a/accepter.tf
+++ b/accepter.tf
@@ -92,7 +92,7 @@ locals {
   accepter_aws_rt_map                    = { for s in local.accepter_subnet_ids : s => try(data.aws_route_tables.accepter[s].ids[0], local.accepter_aws_default_rt_id) }
   accepter_aws_route_table_ids           = distinct(sort(values(local.accepter_aws_rt_map)))
   accepter_aws_route_table_ids_count     = length(local.accepter_aws_route_table_ids)
-  accepter_cidr_block_associations       = flatten(data.aws_vpc.accepter.*.cidr_block_associations)
+  accepter_cidr_block_associations       = [ for assoc in flatten(data.aws_vpc.accepter.*.cidr_block_associations) : assoc if !(contains(var.accepter_exclude_cidrs, assoc.cidr_block)) ]
   accepter_cidr_block_associations_count = length(local.accepter_cidr_block_associations)
 }
 

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -16,6 +16,8 @@ accepter_aws_assume_role_arn = ""
 
 accepter_region = "us-east-2"
 
+accepter_exclude_cidrs = ["100.64.0.0/16"]
+
 accepter_allow_remote_vpc_dns_resolution = true
 
 availability_zones = ["us-east-2b"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,6 +14,7 @@ module "vpc_peering_cross_account" {
   accepter_aws_assume_role_arn             = var.accepter_aws_assume_role_arn
   accepter_region                          = var.accepter_region
   accepter_vpc_id                          = var.accepter_vpc_id
+  accepter_exclude_cidrs                   = var.accepter_exclude_cidrs
   accepter_allow_remote_vpc_dns_resolution = var.accepter_allow_remote_vpc_dns_resolution
 
   context = module.this.context

--- a/requester.tf
+++ b/requester.tf
@@ -50,6 +50,12 @@ variable "requester_vpc_tags" {
   default     = {}
 }
 
+variable "requester_exclude_cidrs" {
+  type        = list
+  description = "Requester VPC CIDRs for which no routes should be created"
+  default     = []
+}
+
 variable "requester_allow_remote_vpc_dns_resolution" {
   type        = bool
   default     = true
@@ -162,7 +168,7 @@ resource "aws_vpc_peering_connection_options" "requester" {
 locals {
   requester_aws_route_table_ids           = try(distinct(sort(data.aws_route_table.requester.*.route_table_id)), [])
   requester_aws_route_table_ids_count     = length(local.requester_aws_route_table_ids)
-  requester_cidr_block_associations       = flatten(data.aws_vpc.requester.*.cidr_block_associations)
+  requester_cidr_block_associations       = [ for assoc in flatten(data.aws_vpc.requester.*.cidr_block_associations) : assoc if !(contains(var.requester_exclude_cidrs, assoc.cidr_block)) ]
   requester_cidr_block_associations_count = length(local.requester_cidr_block_associations)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "accepter_vpc_tags" {
   default     = {}
 }
 
+variable "accepter_exclude_cidrs" {
+  type        = list
+  description = "Accepter VPC CIDRs for which no routes should be created"
+  default     = []
+}
+
 variable "accepter_subnet_tags" {
   type        = map(string)
   description = "Only add peer routes to accepter VPC route tables of subnets matching these tags"


### PR DESCRIPTION
## what

Added the ability to exclude (secondary) VPC cidr associations from routes by specifying the cidr blocks that need to be excluded.

## why

We hit a use case where a CI/CD account (requester) needs network access to several target accounts (accepters) that have a secondary cidr association (`100.64.0.0/16`). This would result in multiple routes in the requester route tables for that cidr, which obviously won't work.

Also possible would be the case where the requester VPC itself _also_ would have a similar secondary cidr, which would also cause problems

## references

See update in examples folder for how to use