### PR TITLE
Better support for omitting role_arn

### DIFF
--- a/accepter.tf
+++ b/accepter.tf
@@ -6,7 +6,7 @@ provider "aws" {
   skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {
-    for_each = var.accepter_aws_assume_role_arn != "" ? ["true"] : []
+    for_each = coalesce(var.accepter_aws_assume_role_arn, "") != "" ? ["true"] : []
     content {
       role_arn = var.accepter_aws_assume_role_arn
     }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -6,6 +6,7 @@ variable "region" {
 variable "requester_aws_assume_role_arn" {
   type        = string
   description = "Requester AWS Assume Role ARN"
+  default     = null
 }
 
 variable "requester_region" {

--- a/requester.tf
+++ b/requester.tf
@@ -13,6 +13,7 @@ variable "requester_aws_access_key" {
 variable "requester_aws_assume_role_arn" {
   description = "Requester AWS Assume Role ARN"
   type        = string
+  default     = null
 }
 
 variable "requester_aws_secret_key" {
@@ -64,7 +65,7 @@ provider "aws" {
   skip_metadata_api_check = var.skip_metadata_api_check
 
   dynamic "assume_role" {
-    for_each = var.requester_aws_assume_role_arn != "" ? ["true"] : []
+    for_each = coalesce(var.requester_aws_assume_role_arn, "") != "" ? ["true"] : []
     content {
       role_arn = var.requester_aws_assume_role_arn
     }


### PR DESCRIPTION
## what

I recently started getting warnings about a missing aws provider `role_arn` value.

```
╷
│ Warning: Missing required argument
│
│   with provider["registry.opentofu.org/hashicorp/aws"],
│   on main.tf line 46, in provider "aws":
│   46: provider "aws" {
│
│ The argument "role_arn" is required, but no definition was found.
│
│ This will be an error in a future release.
╵
```

This seems to be because the `accepter_aws_assume_role_arn` variable has a default of `null` but is checked against empty string, meaning the `assume_role` block is incorrectly included with null `role_arn` when the variable is omitted.

Also, I'm not using an explicit `requester_aws_assume_role_arn` either so it would be nice if that variable had an empty default value just like `accepter_aws_assume_role_arn`.

## why

The warning creates unnecessary noise and will be escalated to an error in future apparently.