### PR TITLE
Remove hardcoded providers to enable for_each/count

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,128 @@
+# Migration Guide: v1.x to v2.0
+
+## Breaking Change: Provider Configuration
+
+In v2.0, the module no longer contains hardcoded `provider "aws"` blocks. Instead, it uses `configuration_aliases` and expects providers to be passed in by the caller. This enables the module to be used with `for_each`, `count`, and `depends_on`.
+
+## Removed Variables
+
+The following variables have been removed. Provider configuration (region, credentials, assume role) is now handled by defining providers in your root module.
+
+| Removed Variable | Previously Used For |
+|---|---|
+| `requester_aws_assume_role_arn` | IAM role to assume for the requester account |
+| `requester_region` | AWS region of the requester |
+| `requester_aws_profile` | AWS CLI profile for the requester |
+| `requester_aws_access_key` | Access key for the requester |
+| `requester_aws_secret_key` | Secret key for the requester |
+| `requester_aws_token` | Session token for the requester |
+| `accepter_aws_assume_role_arn` | IAM role to assume for the accepter account |
+| `accepter_region` | AWS region of the accepter |
+| `accepter_aws_profile` | AWS CLI profile for the accepter |
+| `accepter_aws_access_key` | Access key for the accepter |
+| `accepter_aws_secret_key` | Secret key for the accepter |
+| `accepter_aws_token` | Session token for the accepter |
+| `skip_metadata_api_check` | Skip EC2 metadata API check on providers |
+
+## Migration Steps
+
+### Before (v1.x)
+
+```hcl
+module "vpc_peering" {
+  source  = "cloudposse/vpc-peering-multi-account/aws"
+  version = "~> 1.0"
+
+  requester_aws_assume_role_arn             = "arn:aws:iam::111111111111:role/peering-role"
+  requester_region                          = "us-west-2"
+  requester_vpc_id                          = "vpc-xxxxxxxx"
+  requester_allow_remote_vpc_dns_resolution = true
+
+  accepter_aws_assume_role_arn             = "arn:aws:iam::222222222222:role/peering-role"
+  accepter_region                          = "us-east-1"
+  accepter_vpc_id                          = "vpc-yyyyyyyy"
+  accepter_allow_remote_vpc_dns_resolution = true
+}
+```
+
+### After (v2.0)
+
+```hcl
+# 1. Define providers in your root module
+provider "aws" {
+  alias  = "requester"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::111111111111:role/peering-role"
+  }
+}
+
+provider "aws" {
+  alias  = "accepter"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::222222222222:role/peering-role"
+  }
+}
+
+# 2. Pass providers explicitly and remove deleted variable arguments
+module "vpc_peering" {
+  source  = "cloudposse/vpc-peering-multi-account/aws"
+  version = "~> 2.0"
+
+  providers = {
+    aws.requester = aws.requester
+    aws.accepter  = aws.accepter
+  }
+
+  requester_vpc_id                          = "vpc-xxxxxxxx"
+  requester_allow_remote_vpc_dns_resolution = true
+
+  accepter_vpc_id                          = "vpc-yyyyyyyy"
+  accepter_allow_remote_vpc_dns_resolution = true
+}
+```
+
+### Key Differences
+
+1. **Define providers externally** -- Create `provider "aws"` blocks with `alias = "requester"` and `alias = "accepter"` in your root module, including region, assume_role, and any credential configuration.
+2. **Pass providers to the module** -- Add a `providers` block to the module call mapping `aws.requester` and `aws.accepter`.
+3. **Remove deleted arguments** -- Delete `requester_region`, `requester_aws_assume_role_arn`, `accepter_region`, `accepter_aws_assume_role_arn`, and all other removed variables from the module call.
+
+## Using `for_each` (New Capability)
+
+With v2.0, you can now loop over the module:
+
+```hcl
+locals {
+  peering_configs = {
+    "dev-to-shared" = {
+      requester_vpc_id = "vpc-aaa"
+      accepter_vpc_id  = "vpc-bbb"
+    }
+    "dev-to-prod" = {
+      requester_vpc_id = "vpc-aaa"
+      accepter_vpc_id  = "vpc-ccc"
+    }
+  }
+}
+
+module "vpc_peering" {
+  source   = "cloudposse/vpc-peering-multi-account/aws"
+  for_each = local.peering_configs
+
+  providers = {
+    aws.requester = aws.requester
+    aws.accepter  = aws.accepter
+  }
+
+  requester_vpc_id = each.value.requester_vpc_id
+  accepter_vpc_id  = each.value.accepter_vpc_id
+}
+```
+
+## State Migration
+
+Since only provider configuration was removed (no resources changed), upgrading should not require state manipulation. However, we recommend running `terraform plan` after upgrading to confirm no unexpected changes before applying.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ However, Terraform only allows the VPC Peering Connection to be deleted from the
 For a complete example, see [examples/complete](examples/complete)
 
 ```hcl
+provider "aws" {
+  alias  = "requester"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
+  }
+}
+
+provider "aws" {
+  alias  = "accepter"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
+  }
+}
+
 module "vpc_peering_cross_account" {
   source = "cloudposse/vpc-peering-multi-account/aws"
   # Cloud Posse recommends pinning every module to a specific version
@@ -74,13 +92,14 @@ module "vpc_peering_cross_account" {
   stage            = "dev"
   name             = "cluster"
 
-  requester_aws_assume_role_arn             = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
-  requester_region                          = "us-west-2"
+  providers = {
+    aws.requester = aws.requester
+    aws.accepter  = aws.accepter
+  }
+
   requester_vpc_id                          = "vpc-xxxxxxxx"
   requester_allow_remote_vpc_dns_resolution = true
 
-  accepter_aws_assume_role_arn             = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
-  accepter_region                          = "us-east-1"
   accepter_vpc_id                          = "vpc-yyyyyyyy"
   accepter_allow_remote_vpc_dns_resolution = true
 }
@@ -324,13 +343,7 @@ For more information on IAM policies and permissions for VPC peering, see [Creat
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_accepter_allow_remote_vpc_dns_resolution"></a> [accepter\_allow\_remote\_vpc\_dns\_resolution](#input\_accepter\_allow\_remote\_vpc\_dns\_resolution) | Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC | `bool` | `true` | no |
-| <a name="input_accepter_aws_access_key"></a> [accepter\_aws\_access\_key](#input\_accepter\_aws\_access\_key) | Access key id to use in accepter account | `string` | `null` | no |
-| <a name="input_accepter_aws_assume_role_arn"></a> [accepter\_aws\_assume\_role\_arn](#input\_accepter\_aws\_assume\_role\_arn) | Accepter AWS Assume Role ARN | `string` | `null` | no |
-| <a name="input_accepter_aws_profile"></a> [accepter\_aws\_profile](#input\_accepter\_aws\_profile) | Profile used to assume accepter\_aws\_assume\_role\_arn | `string` | `""` | no |
-| <a name="input_accepter_aws_secret_key"></a> [accepter\_aws\_secret\_key](#input\_accepter\_aws\_secret\_key) | Secret access key to use in accepter account | `string` | `null` | no |
-| <a name="input_accepter_aws_token"></a> [accepter\_aws\_token](#input\_accepter\_aws\_token) | Session token for validating temporary credentials | `string` | `null` | no |
 | <a name="input_accepter_enabled"></a> [accepter\_enabled](#input\_accepter\_enabled) | Flag to enable/disable the accepter side of the peering connection | `bool` | `true` | no |
-| <a name="input_accepter_region"></a> [accepter\_region](#input\_accepter\_region) | Accepter AWS region | `string` | n/a | yes |
 | <a name="input_accepter_subnet_tags"></a> [accepter\_subnet\_tags](#input\_accepter\_subnet\_tags) | Only add peer routes to accepter VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | <a name="input_accepter_vpc_id"></a> [accepter\_vpc\_id](#input\_accepter\_vpc\_id) | Accepter VPC ID filter | `string` | `""` | no |
 | <a name="input_accepter_vpc_tags"></a> [accepter\_vpc\_tags](#input\_accepter\_vpc\_tags) | Accepter VPC Tags filter | `map(string)` | `{}` | no |
@@ -354,16 +367,9 @@ For more information on IAM policies and permissions for VPC peering, see [Creat
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | ID element. Usually an abbreviation of your organization name, e.g. 'eg' or 'cp', to help ensure generated IDs are globally unique | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Terraform regular expression (regex) string.<br/>Characters matching the regex will be removed from the ID elements.<br/>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_requester_allow_remote_vpc_dns_resolution"></a> [requester\_allow\_remote\_vpc\_dns\_resolution](#input\_requester\_allow\_remote\_vpc\_dns\_resolution) | Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC | `bool` | `true` | no |
-| <a name="input_requester_aws_access_key"></a> [requester\_aws\_access\_key](#input\_requester\_aws\_access\_key) | Access key id to use in requester account | `string` | `null` | no |
-| <a name="input_requester_aws_assume_role_arn"></a> [requester\_aws\_assume\_role\_arn](#input\_requester\_aws\_assume\_role\_arn) | Requester AWS Assume Role ARN | `string` | n/a | yes |
-| <a name="input_requester_aws_profile"></a> [requester\_aws\_profile](#input\_requester\_aws\_profile) | Profile used to assume requester\_aws\_assume\_role\_arn | `string` | `""` | no |
-| <a name="input_requester_aws_secret_key"></a> [requester\_aws\_secret\_key](#input\_requester\_aws\_secret\_key) | Secret access key to use in requester account | `string` | `null` | no |
-| <a name="input_requester_aws_token"></a> [requester\_aws\_token](#input\_requester\_aws\_token) | Session token for validating temporary credentials | `string` | `null` | no |
-| <a name="input_requester_region"></a> [requester\_region](#input\_requester\_region) | Requester AWS region | `string` | n/a | yes |
 | <a name="input_requester_subnet_tags"></a> [requester\_subnet\_tags](#input\_requester\_subnet\_tags) | Only add peer routes to requester VPC route tables of subnets matching these tags | `map(string)` | `{}` | no |
 | <a name="input_requester_vpc_id"></a> [requester\_vpc\_id](#input\_requester\_vpc\_id) | Requester VPC ID filter | `string` | `""` | no |
 | <a name="input_requester_vpc_tags"></a> [requester\_vpc\_tags](#input\_requester\_vpc\_tags) | Requester VPC Tags filter | `map(string)` | `{}` | no |
-| <a name="input_skip_metadata_api_check"></a> [skip\_metadata\_api\_check](#input\_skip\_metadata\_api\_check) | Don't use the credentials of EC2 instance profile | `bool` | `false` | no |
 | <a name="input_stage"></a> [stage](#input\_stage) | ID element. Usually used to indicate role, e.g. 'prod', 'staging', 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Additional tags (e.g. `{'BusinessUnit': 'XYZ'}`).<br/>Neither the tag keys nor the tag values will be modified by this module. | `map(string)` | `{}` | no |
 | <a name="input_tenant"></a> [tenant](#input\_tenant) | ID element \_(Rarely used, not included by default)\_. A customer identifier, indicating who this instance of a resource is for | `string` | `null` | no |

--- a/README.yaml
+++ b/README.yaml
@@ -73,6 +73,24 @@ usage: |2-
   For a complete example, see [examples/complete](examples/complete)
 
   ```hcl
+  provider "aws" {
+    alias  = "requester"
+    region = "us-west-2"
+
+    assume_role {
+      role_arn = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
+    }
+  }
+
+  provider "aws" {
+    alias  = "accepter"
+    region = "us-east-1"
+
+    assume_role {
+      role_arn = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
+    }
+  }
+
   module "vpc_peering_cross_account" {
     source = "cloudposse/vpc-peering-multi-account/aws"
     # Cloud Posse recommends pinning every module to a specific version
@@ -81,13 +99,14 @@ usage: |2-
     stage            = "dev"
     name             = "cluster"
 
-    requester_aws_assume_role_arn             = "arn:aws:iam::XXXXXXXX:role/cross-account-vpc-peering-test"
-    requester_region                          = "us-west-2"
+    providers = {
+      aws.requester = aws.requester
+      aws.accepter  = aws.accepter
+    }
+
     requester_vpc_id                          = "vpc-xxxxxxxx"
     requester_allow_remote_vpc_dns_resolution = true
 
-    accepter_aws_assume_role_arn             = "arn:aws:iam::YYYYYYYY:role/cross-account-vpc-peering-test"
-    accepter_region                          = "us-east-1"
     accepter_vpc_id                          = "vpc-yyyyyyyy"
     accepter_allow_remote_vpc_dns_resolution = true
   }

--- a/accepter.tf
+++ b/accepter.tf
@@ -1,22 +1,3 @@
-# Accepter's credentials
-provider "aws" {
-  alias                   = "accepter"
-  region                  = var.accepter_region
-  profile                 = var.accepter_aws_profile
-  skip_metadata_api_check = var.skip_metadata_api_check
-
-  dynamic "assume_role" {
-    for_each = var.accepter_aws_assume_role_arn != "" ? ["true"] : []
-    content {
-      role_arn = var.accepter_aws_assume_role_arn
-    }
-  }
-
-  access_key = var.accepter_aws_access_key
-  secret_key = var.accepter_aws_secret_key
-  token      = var.accepter_aws_token
-}
-
 module "accepter" {
   source  = "cloudposse/label/null"
   version = "0.25.0"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,17 +2,39 @@ provider "aws" {
   region = var.region
 }
 
+provider "aws" {
+  alias  = "requester"
+  region = var.requester_region
+
+  assume_role {
+    role_arn = var.requester_aws_assume_role_arn
+  }
+}
+
+provider "aws" {
+  alias  = "accepter"
+  region = var.accepter_region
+
+  dynamic "assume_role" {
+    for_each = var.accepter_aws_assume_role_arn != null ? [var.accepter_aws_assume_role_arn] : []
+    content {
+      role_arn = assume_role.value
+    }
+  }
+}
+
 module "vpc_peering_cross_account" {
   source = "../../"
 
-  requester_aws_assume_role_arn             = var.requester_aws_assume_role_arn
-  requester_region                          = var.requester_region
+  providers = {
+    aws.requester = aws.requester
+    aws.accepter  = aws.accepter
+  }
+
   requester_vpc_id                          = var.requester_vpc_id
   requester_allow_remote_vpc_dns_resolution = var.requester_allow_remote_vpc_dns_resolution
 
   accepter_enabled                         = var.accepter_enabled
-  accepter_aws_assume_role_arn             = var.accepter_aws_assume_role_arn
-  accepter_region                          = var.accepter_region
   accepter_vpc_id                          = var.accepter_vpc_id
   accepter_allow_remote_vpc_dns_resolution = var.accepter_allow_remote_vpc_dns_resolution
 

--- a/requester.tf
+++ b/requester.tf
@@ -1,37 +1,3 @@
-variable "requester_aws_profile" {
-  description = "Profile used to assume requester_aws_assume_role_arn"
-  type        = string
-  default     = ""
-}
-
-variable "requester_aws_access_key" {
-  description = "Access key id to use in requester account"
-  type        = string
-  default     = null
-}
-
-variable "requester_aws_assume_role_arn" {
-  description = "Requester AWS Assume Role ARN"
-  type        = string
-}
-
-variable "requester_aws_secret_key" {
-  description = "Secret access key to use in requester account"
-  type        = string
-  default     = null
-}
-
-variable "requester_aws_token" {
-  description = "Session token for validating temporary credentials"
-  type        = string
-  default     = null
-}
-
-variable "requester_region" {
-  type        = string
-  description = "Requester AWS region"
-}
-
 variable "requester_subnet_tags" {
   type        = map(string)
   description = "Only add peer routes to requester VPC route tables of subnets matching these tags"
@@ -54,26 +20,6 @@ variable "requester_allow_remote_vpc_dns_resolution" {
   type        = bool
   default     = true
   description = "Allow requester VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the accepter VPC"
-}
-
-# Requestors's credentials
-provider "aws" {
-  alias                   = "requester"
-  region                  = var.requester_region
-  profile                 = var.requester_aws_profile
-  skip_metadata_api_check = var.skip_metadata_api_check
-
-  dynamic "assume_role" {
-    for_each = var.requester_aws_assume_role_arn != "" ? ["true"] : []
-    content {
-      role_arn = var.requester_aws_assume_role_arn
-    }
-  }
-
-  access_key = var.requester_aws_access_key
-  secret_key = var.requester_aws_secret_key
-  token      = var.requester_aws_token
-
 }
 
 module "requester" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,41 +10,6 @@ variable "accepter_enabled" {
   default     = true
 }
 
-variable "accepter_aws_access_key" {
-  description = "Access key id to use in accepter account"
-  type        = string
-  default     = null
-}
-
-variable "accepter_aws_profile" {
-  description = "Profile used to assume accepter_aws_assume_role_arn"
-  type        = string
-  default     = ""
-}
-
-variable "accepter_aws_assume_role_arn" {
-  description = "Accepter AWS Assume Role ARN"
-  type        = string
-  default     = null
-}
-
-variable "accepter_aws_secret_key" {
-  description = "Secret access key to use in accepter account"
-  type        = string
-  default     = null
-}
-
-variable "accepter_aws_token" {
-  description = "Session token for validating temporary credentials"
-  type        = string
-  default     = null
-}
-
-variable "accepter_region" {
-  type        = string
-  description = "Accepter AWS region"
-}
-
 variable "accepter_vpc_id" {
   type        = string
   description = "Accepter VPC ID filter"
@@ -67,12 +32,6 @@ variable "accepter_allow_remote_vpc_dns_resolution" {
   type        = bool
   default     = true
   description = "Allow accepter VPC to resolve public DNS hostnames to private IP addresses when queried from instances in the requester VPC"
-}
-
-variable "skip_metadata_api_check" {
-  type        = bool
-  default     = false
-  description = "Don't use the credentials of EC2 instance profile"
 }
 
 variable "add_attribute_tag" {

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,9 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 2.0"
+      source                = "hashicorp/aws"
+      version               = ">= 2.0"
+      configuration_aliases = [aws.requester, aws.accepter]
     }
   }
 }


### PR DESCRIPTION
## what

- Removed hardcoded `provider "aws"` configuration blocks from the module
- Added `configuration_aliases` to declare the expected provider aliases (`aws.requester` and `aws.accepter`)
- Updated example to define providers at the root level and pass them to the module via the `providers` argument
- Removed 13 provider-related variables that are no longer needed at the module level

## why

This change enables the module to be used with `for_each`, `count`, and `depends_on` — meta-arguments that Terraform does not allow on modules containing provider configurations. Per Terraform's best practices, child modules should never configure providers directly; instead, they should declare `configuration_aliases` and expect the caller to provide pre-configured providers.

## references

- Closes #48
- Closes #108
- [Terraform Provider Configuration in Modules](https://developer.hashicorp.com/terraform/language/modules/develop/providers)